### PR TITLE
Improve snippets; CLI target directory starting with ./

### DIFF
--- a/server/src/devskimWorker.ts
+++ b/server/src/devskimWorker.ts
@@ -361,9 +361,15 @@ export class DevSkimWorker
                             DocumentUtilities.MatchIsInScope(langID, documentContents.substr(0, match.index), newlineIndex, rule.patterns[patternIndex].scopes) &&
                             DevSkimWorker.MatchesConditions(rule.conditions, documentContents, range, langID)) 
                         {
+                            let snippet = [];
+                            for (let i=Math.max(0, lineStart - 2); i<=lineEnd + 2; i++)
+                            {
+                                const snippetLine = DocumentUtilities.GetLine(documentContents, i);
+                                snippet.push(snippetLine.substr(0, 80));
+                            }
 
                             //add in any fixes
-                            let problem: DevSkimProblem = this.MakeProblem(rule, DevSkimWorker.MapRuleSeverity(rule.severity), range, match[0]);
+                            let problem: DevSkimProblem = this.MakeProblem(rule, DevSkimWorker.MapRuleSeverity(rule.severity), range, snippet.join('\n'));
                             problem.fixes = problem.fixes.concat(DevSkimWorker.MakeFixes(rule, replacementSource, range));
                             problem.fixes = problem.fixes.concat(this.dsSuppressions.createActions(rule.id, documentContents, match.index, lineStart, langID, ruleSeverity));
                             problem.filePath = documentURI;

--- a/server/src/utility_classes/pathOperations.ts
+++ b/server/src/utility_classes/pathOperations.ts
@@ -54,6 +54,11 @@ export class PathOperations
         {
             directory = directory.substring(0,directory.length );
         }
+
+        // Chop off any initial ./ or .\ substrings
+        if (directory.slice(0, 2) === './' || directory.slice(0, 2) === '.\\') {
+            directory = directory.slice(2);
+        }
         return directory;        
     }
 


### PR DESCRIPTION
Two changes here:

1. Snippets are now two lines before/after the match instead of just the match text to add context for code reviewers who may not have the full file.
2. If you target the CLI at a directory starting with ./ or .\, it wasn't finding any files there; this fixes that bug.