### PR TITLE
Fixes bugs with processing conditional rules

### DIFF
--- a/server/src/devskimWorker.ts
+++ b/server/src/devskimWorker.ts
@@ -453,7 +453,7 @@ export class DevSkimWorker
                 if(condition.pattern != undefined && condition.pattern && condition.pattern.pattern != undefined &&
                     condition.pattern.pattern && condition.pattern.pattern.length > 0)
                 {
-                    if(DevSkimWorker.MatchesConditionPattern(condition, documentContents, findingRange, langID))
+                    if(!DevSkimWorker.MatchesConditionPattern(condition, documentContents, findingRange, langID))
                     {
                         return false;
                     }
@@ -516,8 +516,8 @@ export class DevSkimWorker
             let regionMatch = XRegExp.exec(condition.search_in, regionRegex);
             if (regionMatch && regionMatch.length > 2) 
             {
-                startPos = DocumentUtilities.GetDocumentPosition(documentContents, findingRange.start.line + regionMatch[1]);
-                endPos = DocumentUtilities.GetDocumentPosition(documentContents, findingRange.end.line + regionMatch[2] + 1);
+                startPos = DocumentUtilities.GetDocumentPosition(documentContents, findingRange.start.line + +regionMatch[1]);
+                endPos = DocumentUtilities.GetDocumentPosition(documentContents, findingRange.end.line + +regionMatch[2] + 1);
             }
         }
         let foundPattern = false;


### PR DESCRIPTION
# Fix Issues #55 and #56 

## What

* Add unary operators to the regex matches on finding-region(-5,5) to convert them from strings to integers

* Invert logic so that pattern matches for a conditional rules only return false when there isn't a match

# Why

These bugs were causing conditions for DevSkim rules to break through not being correctly searched for or being incorrectly labeled 

